### PR TITLE
Validation updates to match new requirements

### DIFF
--- a/AlexaSkillsKit.Lib/Sdk.cs
+++ b/AlexaSkillsKit.Lib/Sdk.cs
@@ -10,7 +10,6 @@ namespace AlexaSkillsKit
         public const string CHARACTER_ENCODING = "UTF-8";
         public const string ECHO_API_DOMAIN_NAME = "echo-api.amazon.com";
         public const string SIGNATURE_CERT_URL_REQUEST_HEADER = "SignatureCertChainUrl";
-        public const string SIGNATURE_CERT_URL_MASK_REGEX = @"https://s3.amazonaws.com/echo.api/(\S+)";
         public const string SIGNATURE_CERT_TYPE = "X.509";
         public const string SIGNATURE_REQUEST_HEADER = "Signature";
         public const string SIGNATURE_ALGORITHM = "SHA1withRSA";


### PR DESCRIPTION
I also had trouble getting my skill to pass certification as @jimgardner99 did in issue #5  

I used his URL validation as a start, but while he somehow got through certification, I was not so lucky.  Going back and forth with Amazon, they would give me examples where it would fail (or not fail) the verification .... but when I would test myself (later), it would work fine.  

I then noticed the cert was being cached, but the cache key for the cert was the same for ALL certs.  The below change appends the URL to the cache key so that it is unique for each cert.  (My skill was finally approved today).