### PR TITLE
Added a fix for the parsing of the timestamp from the Amazon request.…

### DIFF
--- a/AlexaSkillsKit.Lib/AlexaSkillsKit.Lib.csproj
+++ b/AlexaSkillsKit.Lib/AlexaSkillsKit.Lib.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Authentication\SpeechletRequestValidationResult.cs" />
     <Compile Include="Authentication\SpeechletRequestSignatureVerifier.cs" />
     <Compile Include="Authentication\SpeechletRequestTimestampVerifier.cs" />
+    <Compile Include="Helpers\DateTimeUtils.cs" />
     <Compile Include="HttpHelpers.cs" />
     <Compile Include="Json\SpeechletRequestEnvelope.cs" />
     <Compile Include="Json\SpeechletResponseEnvelope.cs" />

--- a/AlexaSkillsKit.Lib/Helpers/DateTimeUtils.cs
+++ b/AlexaSkillsKit.Lib/Helpers/DateTimeUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace AlexaSkillsKit.Helpers
 {
@@ -11,7 +12,7 @@ namespace AlexaSkillsKit.Helpers
                 DateTime datetime;
 
                 //Try a generic parse
-                if (DateTime.TryParse(datetimeString, out datetime))
+                if (DateTime.TryParse(datetimeString, CultureInfo.InvariantCulture, DateTimeStyles.None, out datetime))
                 {
                     return datetime;
                 }

--- a/AlexaSkillsKit.Lib/Helpers/DateTimeUtils.cs
+++ b/AlexaSkillsKit.Lib/Helpers/DateTimeUtils.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace AlexaSkillsKit.Helpers
+{
+    public class DateTimeUtils
+    {
+        public static DateTime FromAmazonRequest(string datetimeString)
+        {
+            try
+            {
+                DateTime datetime;
+
+                //Try a generic parse
+                if (DateTime.TryParse(datetimeString, out datetime))
+                {
+                    return datetime;
+                }
+
+                //Try a ticks parse
+                long ticks;
+                long.TryParse(datetimeString, out ticks);
+                if (ticks > 0)
+                {
+                    var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                    datetime = epoch.AddMilliseconds(ticks);
+                    return datetime;
+                }
+
+                //Try an offset parse for the Iso format
+                var offset = DateTimeOffset.Parse(datetimeString);
+                return offset.DateTime;
+            }
+            catch (Exception e)
+            {
+                return DateTime.Now;
+            }
+        }
+    }
+}

--- a/AlexaSkillsKit.Lib/Json/SpeechletRequestEnvelope.cs
+++ b/AlexaSkillsKit.Lib/Json/SpeechletRequestEnvelope.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using AlexaSkillsKit.Helpers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using AlexaSkillsKit.Speechlet;
@@ -40,7 +41,7 @@ namespace AlexaSkillsKit.Json
             JObject requestJson = json.Value<JObject>("request");
             string requestType = requestJson.Value<string>("type");
             string requestId = requestJson.Value<string>("requestId");
-            DateTime timestamp = requestJson.Value<DateTime>("timestamp");
+            DateTime timestamp = DateTimeUtils.FromAmazonRequest(requestJson.Value<string>("timestamp"));
             switch (requestType) {
                 case "LaunchRequest":
                     request = new LaunchRequest(requestId, timestamp);

--- a/AlexaSkillsKit.Tests/AlexaSkillsKit.Tests.csproj
+++ b/AlexaSkillsKit.Tests/AlexaSkillsKit.Tests.csproj
@@ -66,6 +66,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Authentication\SignatureVerifierTests.cs" />
+    <Compile Include="Helpers\DateTimeUtilsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/AlexaSkillsKit.Tests/Helpers/DateTimeUtilsTests.cs
+++ b/AlexaSkillsKit.Tests/Helpers/DateTimeUtilsTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using AlexaSkillsKit.Helpers;
+using Xunit;
+
+namespace AlexaSkillsKit.Tests.Helpers
+{
+    public class DateTimeUtilsTests
+    {
+        [Fact]
+        public void FromAmazonRequestIso8601Test()
+        {
+            var datetime = new DateTime(2017, 7, 14, 13, 57, 18, 208);
+            var iso8601 = datetime.ToString("o");
+
+            var returnedDate = DateTimeUtils.FromAmazonRequest(iso8601);
+            Assert.Equal(datetime, returnedDate);
+        }
+
+        [Fact]
+        public void FromAmazonRequestStringTicksTest()
+        {
+            var ticks = "1500040638208";
+            var tickDate = new DateTime(2017, 7, 14, 13, 57, 18, 208, DateTimeKind.Utc);
+
+            var returnedDate = DateTimeUtils.FromAmazonRequest(ticks);            
+            Assert.Equal(tickDate, returnedDate);
+        }
+
+        [Fact]
+        public void FromAmazonRequestSortableOutputFailTest()
+        {
+            var datetime = new DateTime(2017, 7, 14, 13, 57, 18, 208);
+            var sortable = datetime.ToString("s");
+
+            var returnedDate = DateTimeUtils.FromAmazonRequest(sortable);
+            Assert.NotEqual(datetime, returnedDate);
+        }
+
+        [Fact]
+        public void FromAmazonRequestBadStringFailTest()
+        {
+            var datetime = new DateTime(2017, 7, 14, 13, 57, 18, 208);
+            var garbage = "2017/7.14";
+
+            var returnedDate = DateTimeUtils.FromAmazonRequest(garbage);
+            Assert.NotEqual(datetime, returnedDate);
+        }
+    }
+}


### PR DESCRIPTION
… Sometimes the timestamp can vary. Amazon started sending the date in epoch in their test harness about 3 days ago. This code change can do the Iso 8601 format and the epoch date.