### PR TITLE
Fix a break due to if intent doesnt have any slots, AWS doesn't add Slots : {} to the JSON

### DIFF
--- a/AlexaSkillsKit.Lib/Slu/Intent.cs
+++ b/AlexaSkillsKit.Lib/Slu/Intent.cs
@@ -28,7 +28,7 @@ namespace AlexaSkillsKit.Slu
             return new Intent {
                 Name = json.Value<string>("name"),
                 ConfirmationStatus = confirmationStatus,
-                Slots = slots
+                Slots = slots ?? new Dictionary<string, Slot>()
             };
         }
 

--- a/AlexaSkillsKit.Lib/Speechlet/Speechlet.cs
+++ b/AlexaSkillsKit.Lib/Speechlet/Speechlet.cs
@@ -1,6 +1,7 @@
 ﻿//  Copyright 2015 Stefan Negritoiu (FreeBusy). See LICENSE file for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
@@ -177,6 +178,10 @@ namespace AlexaSkillsKit.Speechlet
         /// </summary>
         private void DoSessionManagement(IntentRequest request, Session session) {
             if (request == null) return;
+
+            if (session.Attributes == null) {
+                session.Attributes = new Dictionary<string, string>();
+            }
 
             if (session.IsNew) {
                 session.Attributes[Session.INTENT_SEQUENCE] = request.Intent.Name;

--- a/AlexaSkillsKit.Lib/Speechlet/SpeechletAsync.cs
+++ b/AlexaSkillsKit.Lib/Speechlet/SpeechletAsync.cs
@@ -1,6 +1,7 @@
 ﻿//  Copyright 2015 Stefan Negritoiu (FreeBusy). See LICENSE file for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
@@ -180,6 +181,10 @@ namespace AlexaSkillsKit.Speechlet
             if (request == null) return;
 
             if (session.IsNew) {
+                if (session.Attributes == null)
+                {
+                    session.Attributes = new Dictionary<string, string>();
+                }
                 session.Attributes[Session.INTENT_SEQUENCE] = request.Intent.Name;
             }
             else {

--- a/AlexaSkillsKit.Lib/Speechlet/SpeechletAsync.cs
+++ b/AlexaSkillsKit.Lib/Speechlet/SpeechletAsync.cs
@@ -180,11 +180,11 @@ namespace AlexaSkillsKit.Speechlet
         private void DoSessionManagement(IntentRequest request, Session session) {
             if (request == null) return;
 
+            if (session.Attributes == null) {
+                session.Attributes = new Dictionary<string, string>();
+            }
+
             if (session.IsNew) {
-                if (session.Attributes == null)
-                {
-                    session.Attributes = new Dictionary<string, string>();
-                }
                 session.Attributes[Session.INTENT_SEQUENCE] = request.Intent.Name;
             }
             else {


### PR DESCRIPTION
This is due to the if the intent doesn't have any slots, AWS/alexa doesn't add "slots: {}" to the JSON. Same issue to the Attributes when the session starts. 