### PR TITLE
Don't demand specific dependency assembly versions

### DIFF
--- a/AlexaSkillsKit.Lib/AlexaSkillsKit.Lib.csproj
+++ b/AlexaSkillsKit.Lib/AlexaSkillsKit.Lib.csproj
@@ -34,10 +34,12 @@
   <ItemGroup>
     <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
       <HintPath>..\packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
Currently Library cannot be used with newer versions of Newtonsoft.Json and BouncyCastle. It is artificial restriction in project settings, rather then NuGet specification.